### PR TITLE
Update README.md | fix deployment example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ spec:
     spec:
       containers:
         - name: cpu-stressor
-          image: narmidm/k8s-pod-cpu-stressor:1.0.0
+          image: narmidm/k8s-pod-cpu-stressor:1.1.0
           args:
             - "-cpu=0.2"
             - "-duration=10s"


### PR DESCRIPTION
fix: k8s deployment updated 

tag need to be `1.1.0` to work as example described